### PR TITLE
Fixed app icon bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports.start = function start(config) {
             regions: app.regions,
             publisherKey: app.publisherKey,
             verbose: config.verbose,
+            showAppIcon: config.showAppIcon,
             dryRun: config.dryRun,
             botUsername: app.botUsername || config.botUsername,
             botEmoji: app.botEmoji || config.botEmoji,


### PR DESCRIPTION
The `showAppIcon` config option was being used in the rest of the code, but was never being loaded from the config file. With this change, now app icons show up in Slack messages as expected when this value is true.